### PR TITLE
Adding Tests to rk_tomcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,18 @@
+fixtures:
+  repositories:
+    stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
+    inifile: git://github.com/puppetlabs/puppetlabs-inifile.git
+
+
+  forge_modules:
+    firewall: "puppetlabs/firewall"
+    stdlib: "puppetlabs/stdlib"
+    limits: "puppetlabs/limits"
+    wget: "maestrodev/wget"
+    augeasproviders_sysctl: "herculesteam/augeasproviders_sysctl"
+    tomcat:
+       repo: "puppetlabs/tomcat"
+       ref: "1.4.1"
+
+  symlinks:
+    rk_tomcat: "#{source_dir}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,3 @@ DEPENDENCIES
   puppet (>= 4.2, < 4.3)
   puppet-lint (>= 1.0.0)
   puppetlabs_spec_helper (>= 0.8.2)
-
-BUNDLED WITH
-   1.10.6

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 # This code is released under the [MIT License](http://opensource.org/licenses/MIT).
 #
 class rk_tomcat (
-  $stack,
+  $stack ,
   $mode = 'deploy',
 ) {
   validate_re($mode, '^(provision|deploy)$')

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,47 @@
 require 'spec_helper'
-describe 'rk_tomcat' do
 
+describe 'rk_tomcat', :type => :class do
   context 'with defaults for all parameters' do
-    it { should contain_class('rk_tomcat') }
+    it { should_not compile }
+    #it do
+    #  expect {
+    #    is_expected.to compile
+    #  }.to raise_error(Puppet::PreformattedError, /Must pass stack to Class[Rk_tomcat]/)
+    #end
+    #it { should contain_class('wget') }
+
+    #it { should contain_class('rk_tomcat')}
+    #it { should contain_rk_tomcat__deploy}
+
+  end
+end
+
+describe 'rk_tomcat', :type => :class do
+  context 'with parameter mode set to "provision"' do
+    let (:params) do
+      {
+        :mode  => 'provision',
+        :stack => 'rk-prod-app'
+      }
+    end
+    it { should contain_class('wget')}
+    it { should contain_class('rk_tomcat')}
+    it { should contain_class('rk_tomcat::fonts')}
+    it { should contain_class('rk_tomcat::java')}
+  end
+end
+
+describe 'rk_tomcat', :type => :class do
+  context 'with parameter mode set to "deploy"' do
+    let (:params) do
+      {
+        :mode  => 'deploy',
+        :stack => 'rk-prod-app'
+      }
+    end
+    it { should contain_class('wget')}
+    it { should contain_class('rk_tomcat')}
+    it { should contain_class('rk_tomcat::deploy')}
+    it { should contain_class('rk_tomcat::tomcat')}
   end
 end

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: spec/fixtures/hieradata
+:hierarchy:
+  - secrets
+  - secrets-common
+  - common

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,0 +1,67 @@
+---
+# Java
+rk_tomcat::java::zulu_package: zulu-8
+rk_tomcat::java::zulu_version: 8.17.0.7-1
+
+# Tomcat
+rk_tomcat::tomcat::hosts:
+    localhost:
+      ip: 127.0.0.1
+      host_aliases:
+        - localhost.localdomain
+rk_tomcat::tomcat::logdir: /var/log/tomcat7
+rk_tomcat::tomcat::postgres_driver: postgresql-9.4-1203.jdbc42
+rk_tomcat::tomcat::postgres_tls: false
+rk_tomcat::tomcat::catalina_home: /usr/share/tomcat7
+rk_tomcat::deploy::catalina_home: "%{alias('rk_tomcat::tomcat::catalina_home')}"
+rk_tomcat::deploy::tomcat_svc: "%{alias('rk_tomcat::tomcat::tomcat_svc')}"
+rk_tomcat::deploy::newrelic_enabled: false
+rk_tomcat::kinesis::agent_cfg: /etc/aws-kinesis/agent.json
+rk_tomcat::kinesis::agent_pkg: aws-kinesis-agent
+rk_tomcat::kinesis::agent_svc: aws-kinesis-agent
+rk_tomcat::kinesis::flows:
+  -
+rk_tomcat::limits::nofile: 65536
+rk_tomcat::rsyslog::deploy::catalina_home: "%{alias('rk_tomcat::tomcat::catalina_home')}"
+rk_tomcat::tomcat::tomcat_instance: default
+rk_tomcat::tomcat::tomcat_pkg: tomcat7
+rk_tomcat::tomcat::tomcat_native_pkg: tomcat-native
+rk_tomcat::tomcat::tomcat_svc: tomcat7
+rk_tomcat::tomcat::tomcat_user: tomcat
+rk_tomcat::tomcat::tomcat_group: tomcat
+rk_tomcat::tomcat::tomcat_jars_context_skip:
+  - "*"
+
+# New Relic
+rk_tomcat::newrelic::catalina_home: "%{alias('rk_tomcat::tomcat::catalina_home')}"
+rk_tomcat::newrelic::tomcat_user: "%{alias('rk_tomcat::tomcat::tomcat_user')}"
+rk_tomcat::newrelic::tomcat_group: "%{alias('rk_tomcat::tomcat::tomcat_group')}"
+rk_tomcat::newrelic::deploy::newrelic_enabled: "%{alias('rk_tomcat::deploy::newrelic_enabled')}"
+rk_tomcat::newrelic::deploy::staging_instance: "%{alias('rk_tomcat::deploy::staging_instance')}"
+rk_tomcat::newrelic::deploy::artifacts: "%{alias('rk_tomcat::deploy::artifacts')}"
+
+# Goss
+rk_tomcat::goss::destination: /usr/local/bin/goss
+rk_tomcat::goss::version: v0.2.2
+rk_tomcat::goss::catalina_home: "%{alias('rk_tomcat::tomcat::catalina_home')}"
+rk_tomcat::goss::font_pkgs: "%{alias('rk_tomcat::fonts::packages')}"
+rk_tomcat::goss::postgres_driver: "%{alias('rk_tomcat::tomcat::postgres_driver')}"
+rk_tomcat::goss::tomcat_native_pkg: "%{alias('rk_tomcat::tomcat::tomcat_native_pkg')}"
+rk_tomcat::goss::tomcat_pkg: "%{alias('rk_tomcat::tomcat::tomcat_pkg')}"
+rk_tomcat::goss::tomcat_svc: "%{alias('rk_tomcat::tomcat::tomcat_svc')}"
+rk_tomcat::goss::tomcat_user: "%{alias('rk_tomcat::tomcat::tomcat_user')}"
+rk_tomcat::goss::tomcat_group: "%{alias('rk_tomcat::tomcat::tomcat_group')}"
+rk_tomcat::goss::tomcat_logdir: "%{alias('rk_tomcat::tomcat::logdir')}"
+rk_tomcat::goss::zulu_package: "%{alias('rk_tomcat::java::zulu_package')}"
+rk_tomcat::goss::zulu_version: "%{alias('rk_tomcat::java::zulu_version')}"
+
+# Fonts
+rk_tomcat::fonts::packages:
+  - cjkuni-fonts-common
+  - cjkuni-fonts-ghostscript
+  - cjkuni-ukai-fonts
+  - cjkuni-uming-fonts
+  - wqy-zenhei-fonts
+
+rk_tomcat::rsyslog::datahub_host: localhost
+rk_tomcat::rsyslog::datahub_port: 1234

--- a/spec/fixtures/hieradata/secrets-common.yaml
+++ b/spec/fixtures/hieradata/secrets-common.yaml
@@ -1,0 +1,84 @@
+---
+# Tomcat
+rk_tomcat::stack: rk-stage-app
+rk_tomcat::deploy::stack: "%{alias('rk_tomcat::stack')}"
+rk_tomcat::deploy::aws_keys:
+    sqs:
+        access_key: AKKKKKKKKKKKKKKKKKKK
+        secret_key: lTTTT/TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+    s3:
+        analytics:
+          access_key: AKKKKKKKKKKKKKKKKKKK
+          secret_key: lTTTT/TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+
+rk_tomcat::deploy::artifacts:
+    dashboard: ROOT.war
+    webapi: RunKeeper.war
+    devapi: devapi.war
+    queuekeeper: queuekeeper.war
+    admin: admin.war
+rk_tomcat::deploy::cloudant_user: user
+rk_tomcat::deploy::cloudant_password: password
+rk_tomcat::deploy::cloudant_host: example.cloudant.com
+rk_tomcat::deploy::deploy_user: user
+rk_tomcat::deploy::deploy_password: password
+rk_tomcat::deploy::logentries_tokens:
+    analytics: token-token-token-token-token
+    applogs: token-token-token-token-token
+rk_tomcat::deploy::postgres:
+    master:
+        db: "rk%{hiera('rk_tomcat::deploy::staging_instance')}"
+        user: user
+        password: password
+        name: exampleMaster
+        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        port: 5432
+        max_conn: 3
+    trip:
+        db: "rk%{hiera('rk_tomcat::deploy::staging_instance')}"
+        user: user
+        password: password
+        name: exampleFinalizeTrip
+        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        port: 5432
+        max_conn: 3
+    replica1:
+        db: "rk%{hiera('rk_tomcat::deploy::staging_instance')}"
+        user: user
+        password: password
+        name: exampleReplica1
+        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        port: 5432
+        max_conn: 3
+rk_tomcat::deploy::redis_host: "redis.%{hiera('rk_tomcat::stack')}.vpc.rkcloud.us"
+rk_tomcat::deploy::redis_port: 6379
+rk_tomcat::deploy::redis_pushnotif_db: "%{hiera('rk_tomcat::deploy::staging_number')}005"
+rk_tomcat::deploy::redis_queue_db: "%{hiera('rk_tomcat::deploy::staging_number')}006"
+rk_tomcat::deploy::s3_path: 'rk-devops-${REGION}/jenkins/builds'
+rk_tomcat::deploy::staging_instance: "stage%{hiera('rk_tomcat::deploy::staging_number')}"
+rk_tomcat::newrelic::deploy::staging_instance: "%{alias('rk_tomcat::deploy::staging_instance')}"
+rk_tomcat::newrelic::deploy::license: 9999999999999999999999999999999999999999
+rk_tomcat::newrelic::deploy::artifacts: "%{alias('rk_tomcat::deploy::artifacts')}"
+rk_tomcat::newrelic::deploy::app_name: Staging
+rk_tomcat::newrelic::deploy::attr_include:
+    - request.parameters.*
+    - message.parameters.*
+rk_tomcat::newrelic::deploy::attr_exclude:
+    - request.parameters.password
+    - request.parameters.ACCT
+    - request.parameters.CVV2
+
+# Jenkins
+rk_jenkins::master::users:
+    admin:
+        password: 'password'
+        email: 'devops+jenkins@example.com'
+rk_jenkins::builder::ui_user: Example-CI
+rk_jenkins::builder::ui_pass: token
+jenkins::localstatedir: "%{alias('rk_jenkins::master::volume::mountpoint')}"
+
+# DataHub
+rk_datahub::tier: staging
+rk_datahub::user_keys:
+    production: token-token-token-token-token
+    staging: "%{alias('rk_data::user_key.production')}"

--- a/spec/fixtures/hieradata/secrets-common.yaml
+++ b/spec/fixtures/hieradata/secrets-common.yaml
@@ -13,10 +13,11 @@ rk_tomcat::deploy::aws_keys:
 
 rk_tomcat::deploy::artifacts:
     dashboard: ROOT.war
-    webapi: RunKeeper.war
-    devapi: devapi.war
-    queuekeeper: queuekeeper.war
-    admin: admin.war
+    example1: example1.war
+    example2: example2.war
+    example3: example3.war
+    example4: example4.war
+    example5: example5.war
 rk_tomcat::deploy::cloudant_user: user
 rk_tomcat::deploy::cloudant_password: password
 rk_tomcat::deploy::cloudant_host: example.cloudant.com
@@ -31,7 +32,7 @@ rk_tomcat::deploy::postgres:
         user: user
         password: password
         name: exampleMaster
-        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        host: example-stage.example.com
         port: 5432
         max_conn: 3
     trip:
@@ -39,7 +40,7 @@ rk_tomcat::deploy::postgres:
         user: user
         password: password
         name: exampleFinalizeTrip
-        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        host: example-stage.example.com
         port: 5432
         max_conn: 3
     replica1:
@@ -47,10 +48,10 @@ rk_tomcat::deploy::postgres:
         user: user
         password: password
         name: exampleReplica1
-        host: example-stage.ca4bhrmkhch7.us-east-1.rds.amazonaws.com
+        host: example-stage.example.com
         port: 5432
         max_conn: 3
-rk_tomcat::deploy::redis_host: "redis.%{hiera('rk_tomcat::stack')}.vpc.rkcloud.us"
+rk_tomcat::deploy::redis_host: "redis.%{hiera('rk_tomcat::stack')}.vpc.example.com"
 rk_tomcat::deploy::redis_port: 6379
 rk_tomcat::deploy::redis_pushnotif_db: "%{hiera('rk_tomcat::deploy::staging_number')}005"
 rk_tomcat::deploy::redis_queue_db: "%{hiera('rk_tomcat::deploy::staging_number')}006"

--- a/spec/fixtures/hieradata/secrets.yaml
+++ b/spec/fixtures/hieradata/secrets.yaml
@@ -1,0 +1,9 @@
+---
+# fake secrets
+rk_tomcat::deploy::redis_pushnotif_host: example.com
+rk_tomcat::deploy::redis_queue_host: example.com
+rk_tomcat::deploy::warname: ROOT.war
+
+rk_tomcat::newrelic::deploy::ignore_status_codes:
+  - 1234
+  - 5678

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'hiera'
+
+RSpec.configure do |c|
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
This commit add tests, fixtures, and related files to add some basic
puppet rspec tests to this module.

Tests can be run with `rake spec  SPEC_OPTS='--format documentation'`
after installing all the ruby gems you need

Working tests, but still a WIP

Bumping the test  version of tomcat_zula

as per b083fd8524d64d1ed429f31700f8efca446fa2f7

Updating init_spec with initial working set of tests

Tests can now be run by running a `bundle install` then running
the rake task `rake spec  SPEC_OPTS='--format documentation'`

Updating tomcat_jars_context_skip in fixtures

This should track production shortly - open PR fro this