### PR TITLE
write out auth information to files on local disk

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -1,0 +1,29 @@
+# rk_tomcat::auth
+#
+# Manage authentication data stored on disk.
+class rk_tomcat::auth(
+  $content,
+  $dir,
+  $owner,
+  $group,
+  $mode,
+) {
+  validate_hash($content)
+
+  file { $dir:
+    ensure => 'directory',
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+  }
+
+  $content.each |$file_name,$file_content| {
+    file { "${dir}/${file_name}":
+      ensure  => 'present',
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
+      content => $file_content,
+    }
+  }
+}

--- a/manifests/deploy.pp
+++ b/manifests/deploy.pp
@@ -145,4 +145,6 @@ class rk_tomcat::deploy (
   class { 'rk_tomcat::rsyslog::deploy':
     application_tag => $log_identifier
   }
+
+  class { 'rk_tomcat::auth': }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -43,5 +43,9 @@ describe 'rk_tomcat', :type => :class do
     it { should contain_class('rk_tomcat')}
     it { should contain_class('rk_tomcat::deploy')}
     it { should contain_class('rk_tomcat::tomcat')}
+    it { should contain_class('rk_tomcat::auth')}
+    it { should contain_class('rk_tomcat::kinesis')}
+    it { should contain_class('rk_tomcat::newrelic::deploy')}
+    it { should contain_class('rk_tomcat::rsyslog::deploy')}
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -27,7 +27,11 @@ describe 'rk_tomcat', :type => :class do
     it { should contain_class('wget')}
     it { should contain_class('rk_tomcat')}
     it { should contain_class('rk_tomcat::fonts')}
+    it { should contain_class('rk_tomcat::goss')}
     it { should contain_class('rk_tomcat::java')}
+    it { should contain_class('rk_tomcat::limits')}
+    it { should contain_class('rk_tomcat::newrelic')}
+    it { should contain_class('rk_tomcat::newrelic::provision')}
   end
 end
 
@@ -46,6 +50,7 @@ describe 'rk_tomcat', :type => :class do
     it { should contain_class('rk_tomcat::auth')}
     it { should contain_class('rk_tomcat::kinesis')}
     it { should contain_class('rk_tomcat::newrelic::deploy')}
+    it { should contain_class('rk_tomcat::rsyslog')}
     it { should contain_class('rk_tomcat::rsyslog::deploy')}
   end
 end

--- a/spec/fixtures/hieradata/secrets-common.yaml
+++ b/spec/fixtures/hieradata/secrets-common.yaml
@@ -1,6 +1,12 @@
 ---
 # Tomcat
 rk_tomcat::stack: rk-stage-app
+rk_tomcat::auth::content:
+    foobar: '{"foo":"bar"}'
+rk_tomcat::auth::dir: "%{hiera('rk_tomcat::deploy::catalina_home')}/auth"
+rk_tomcat::auth::owner: "%{alias('rk_tomcat::tomcat::tomcat_user')}"
+rk_tomcat::auth::group: "%{alias('rk_tomcat::tomcat::tomcat_group')}"
+rk_tomcat::auth::mode: "0400"
 rk_tomcat::deploy::stack: "%{alias('rk_tomcat::stack')}"
 rk_tomcat::deploy::aws_keys:
     sqs:

--- a/spec/fixtures/hieradata/secrets-common.yaml
+++ b/spec/fixtures/hieradata/secrets-common.yaml
@@ -3,7 +3,7 @@
 rk_tomcat::stack: rk-stage-app
 rk_tomcat::auth::content:
     foobar: '{"foo":"bar"}'
-rk_tomcat::auth::dir: "%{hiera('rk_tomcat::deploy::catalina_home')}/auth"
+rk_tomcat::auth::dir: "%{hiera('rk_tomcat::deploy::catalina_home')}/conf/auth"
 rk_tomcat::auth::owner: "%{alias('rk_tomcat::tomcat::tomcat_user')}"
 rk_tomcat::auth::group: "%{alias('rk_tomcat::tomcat::tomcat_group')}"
 rk_tomcat::auth::mode: "0400"


### PR DESCRIPTION
tested on stage22, appears to do the right thing; this is an attempt to impose some standards on the mechanism for transmitting information from our secrets store to the applications.  our previous pattern was specific to a particular configuration library, and putting this stuff in the DB is also a bit laborious