### PR TITLE
Adding Threatstack agent

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,7 +15,7 @@ fixtures:
        ref: "1.4.1"
     threatstack:
        repo: "threatstack/threatstack"
-       ref: "1.5.3"
+       ref: "1.5.4"
 
   symlinks:
     rk_tomcat: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,6 +13,9 @@ fixtures:
     tomcat:
        repo: "puppetlabs/tomcat"
        ref: "1.4.1"
+    threatstack:
+       repo: "threatstack/threatstack"
+       ref: "1.5.3"
 
   symlinks:
     rk_tomcat: "#{source_dir}"

--- a/Puppetfile
+++ b/Puppetfile
@@ -10,6 +10,9 @@ mod 'ripienaar-module_data',
   :git => 'https://github.com/ripienaar/puppet-module-data.git',
   :ref => '324e79829b29734bd711a991baadb27ae5331642'
 
+mod 'threatstack-threatstack',
+  :git => 'https://github.com/threatstack/threatstack-puppet.git'
+
 # use dependencies defined in Modulefile
 # modulefile
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -10,9 +10,6 @@ mod 'ripienaar-module_data',
   :git => 'https://github.com/ripienaar/puppet-module-data.git',
   :ref => '324e79829b29734bd711a991baadb27ae5331642'
 
-mod 'threatstack-threatstack',
-  :git => 'https://github.com/threatstack/threatstack-puppet.git'
-
 # use dependencies defined in Modulefile
 # modulefile
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -62,3 +62,7 @@ rk_tomcat::fonts::packages:
   - cjkuni-ukai-fonts
   - cjkuni-uming-fonts
   - wqy-zenhei-fonts
+
+# threatstack
+rk_tomcat::threatstack::deploy_key: d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA
+rk_tomcat::threatstack::configure_agent: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -65,4 +65,3 @@ rk_tomcat::fonts::packages:
 
 # threatstack
 rk_tomcat::threatstack::deploy_key: d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA
-rk_tomcat::threatstack::configure_agent: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class rk_tomcat (
     class { 'rk_tomcat::deploy':
       require => Class[rk_tomcat::tomcat],
     }
+    class { 'rk_tomcat::threatstack': }
   }
 
   # common dependencies

--- a/manifests/threatstack.pp
+++ b/manifests/threatstack.pp
@@ -1,0 +1,20 @@
+# Wrapper class for threatstack
+class rk_tomcat::threatstack (
+    $deploy_key,
+    $configure_agent,
+){
+  $threatstack_template = @(END)
+runcmd:
+ - [ "/opt/threatstack/bin/cloudsight", "setup", "--deploy-key=<%= $deploy_key -%>" ]
+END
+
+  class { '::threatstack':
+    deploy_key      => $deploy_key,
+    configure_agent => false,
+    #configure_agent => $configure_agent,
+  }
+  file { '/etc/cloud/cloud.cfg.d/99_threatstack.cfg':
+    ensure  => file,
+    content => inline_epp($threatstack_template, {'deploy_key' => $deploy_key}),
+  }
+}

--- a/manifests/threatstack.pp
+++ b/manifests/threatstack.pp
@@ -1,20 +1,13 @@
 # Wrapper class for threatstack
 class rk_tomcat::threatstack (
     $deploy_key,
-    $configure_agent,
 ){
-  $threatstack_template = @(END)
-runcmd:
- - [ "/opt/threatstack/bin/cloudsight", "setup", "--deploy-key=<%= $deploy_key -%>" ]
-END
-
   class { '::threatstack':
     deploy_key      => $deploy_key,
     configure_agent => false,
-    #configure_agent => $configure_agent,
   }
   file { '/etc/cloud/cloud.cfg.d/99_threatstack.cfg':
     ensure  => file,
-    content => inline_epp($threatstack_template, {'deploy_key' => $deploy_key}),
+    content => epp('rk_tomcat/99_threatstack.cfg.epp', {'deploy_key' => $deploy_key}),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,4 +15,3 @@
     {"name":"herculesteam-augeasproviders_sysctl","version_requirement":">= 2.0.2"}
   ]
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,7 @@
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.2 < 1.5.0"},
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},
-    {"name":"herculesteam-augeasproviders_sysctl","version_requirement":">= 2.0.2"}
+    {"name":"herculesteam-augeasproviders_sysctl","version_requirement":">= 2.0.2"},
+    {"name":"threatstack-threatstack","version_requirement":">= 1.5.4"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,10 +18,11 @@ end
 
 describe 'rk_tomcat', :type => :class do
   context 'with parameter mode set to "provision"' do
+    let(:facts) { {:osfamily => 'Amazon'} }
     let (:params) do
       {
         :mode  => 'provision',
-        :stack => 'rk-prod-app'
+        :stack => 'rk-prod-app',
       }
     end
     it { should contain_class('wget')}
@@ -37,6 +38,7 @@ end
 
 describe 'rk_tomcat', :type => :class do
   context 'with parameter mode set to "deploy"' do
+    let(:facts) { {:osfamily => 'Amazon'} }
     let (:params) do
       {
         :mode  => 'deploy',
@@ -44,6 +46,11 @@ describe 'rk_tomcat', :type => :class do
       }
     end
     it { should contain_class('wget')}
+    it { should contain_class('threatstack').with(
+      'deploy_key'      => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA',
+      'configure_agent' => 'false',
+      )
+    }
     it { should contain_class('rk_tomcat')}
     it { should contain_class('rk_tomcat::deploy')}
     it { should contain_class('rk_tomcat::tomcat')}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -48,7 +48,6 @@ describe 'rk_tomcat', :type => :class do
     it { should contain_class('wget')}
     it { should contain_class('threatstack').with(
       'deploy_key'      => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA',
-      'configure_agent' => 'false',
       )
     }
     it { should contain_class('rk_tomcat')}

--- a/spec/classes/threatstack_spec.rb
+++ b/spec/classes/threatstack_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'rk_tomcat::threatstack', :type => :class do
+  context 'with defaults for all parameters' do
+    it { should_not compile }
+  end
+end
+
+describe 'rk_tomcat::threatstack', :type => :class do
+  context 'with parameter mode set to "deploy"' do
+    let(:facts) { {:osfamily => 'Amazon'} }
+    let (:params) do
+      {
+        :deploy_key => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA',
+        :configure_agent => false
+      }
+    end
+    it { should contain_class('threatstack').with(
+      'deploy_key'      => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA',
+      'configure_agent' => 'false',
+      )
+    }
+    it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with(
+      'ensure' => 'file',
+      )
+    }
+    it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with_content(/runcmd:/)
+    }
+    it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with_content(/deploy-key=d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA/)
+    }
+  end
+end

--- a/spec/classes/threatstack_spec.rb
+++ b/spec/classes/threatstack_spec.rb
@@ -11,8 +11,7 @@ describe 'rk_tomcat::threatstack', :type => :class do
     let(:facts) { {:osfamily => 'Amazon'} }
     let (:params) do
       {
-        :deploy_key => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA',
-        :configure_agent => false
+        :deploy_key => 'd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA'
       }
     end
     it { should contain_class('threatstack').with(
@@ -26,7 +25,6 @@ describe 'rk_tomcat::threatstack', :type => :class do
     }
     it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with_content(/runcmd:/)
     }
-    it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with_content(/deploy-key=d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA/)
-    }
+    it { should contain_file('/etc/cloud/cloud.cfg.d/99_threatstack.cfg').with_content(/deploy-key=d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA/)}
   end
 end

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -65,3 +65,7 @@ rk_tomcat::fonts::packages:
 
 rk_tomcat::rsyslog::datahub_host: localhost
 rk_tomcat::rsyslog::datahub_port: 1234
+
+# threatstack
+rk_tomcat::threatstack::deploy_key: d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA
+rk_tomcat::threatstack::configure_agent: false

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -68,4 +68,3 @@ rk_tomcat::rsyslog::datahub_port: 1234
 
 # threatstack
 rk_tomcat::threatstack::deploy_key: d3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yd3adk3yAA
-rk_tomcat::threatstack::configure_agent: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,6 @@ require 'hiera'
 
 RSpec.configure do |c|
   c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  c.parser = 'future' if Puppet.version.to_f >= 4.0
+  c.environmentpath = File.expand_path(File.join(Dir.pwd, 'spec')) if Puppet.version.to_f >= 4.0
 end

--- a/templates/99_threatstack.cfg.epp
+++ b/templates/99_threatstack.cfg.epp
@@ -1,0 +1,2 @@
+runcmd:
+ - [ "/opt/threatstack/bin/cloudsight", "setup", "--deploy-key=<%= $deploy_key -%>" ]


### PR DESCRIPTION
This PR adds the threadstack agent to our app servers, and on insance startup, register threatstack with our deployment key. We should hold off merging this until the threatstack module is updated on the forge to => 1.5.3, and the Puppefile, metadata.json file, and fixtures files are updated in rk_tomcat, other then that this is ready to go!  @FitnessKeeper/devops please give this a review, and comment. 


PLAT-70 #comment first pass at adding the threatstack agent to our
images

Fixing broken JSON

Moving threatstack into a wrapper class

Moving this into a wrapper due to how we are using hiera at the moment

Oh yeah, and the actual class too

:doh:

Moving threatstack from metadata to Puppetfile

Doing this because for testing at least I need to track a branch of our
fork of threatstack

Updated to correctly pull the right branch

Updated Puppetfile for testing

This tests the threatstack branch which fixes wget

Update deploy phose to start threatstack on boot

Deploy key isn't showing up in rc.local

PLAT-70 #comment the deploy key is nul in the file output... rebuilding
the image and trying again

Move threatstack into the deploy phase

PLAT-70 #comment moving threatstack install and config to the deploy
phase

Update your test!

Whoops.. travis failed because I told it to!

Removing hostname from the cloudsight setup

PLAT-70 #comment removing the --hostname argument, as it was picking up
the hostname of the deploy image host, not the hostname of the actual
deployed host. --hostname is optional anyway, so we should still get
the corrent hostname info

Hmmm trying to add FQDN back

PLAT-70 #comment we still aren't getting the nodes checking in with the
right hostname... grrr

Make sure that the configure_agent param is false

PLAT-70 #comment setting the configure agent parameter to false *in the
code* to make sure that the issue we are seeing isn't that hiera isn't
getting called, or populating the value for some reason.

Moving cloudsight setup to cloud-init

PLAT-70 #comment moving the first run of cloudsight set up from the
rc.local script, which seems to run when any run level changes, to the
cloud-init script, which sould only run when an instance starts