### PR TITLE
fix: pin puppetlabs-stdlib < 5.0.0 to fix dependency conflict

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/FitnessKeeper/puppet-rk_tomcat",
   "issues_url": "https://github.com/FitnessKeeper/puppet-rk_tomcat/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.2 < 1.5.0"},
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},


### PR DESCRIPTION
This fixes an error with puppet librarian dependency resolution:

```
[Librarian] Conflict between puppetlabs-stdlib (< 5.0.0, >= 4.2.0) <https://forgeapi.puppetlabs.com> and puppetlabs-stdlib/6.0.0 <https://forgeapi.puppetlabs.com>
Could not resolve the dependencies.
```

(Sidenote, to get puppet librarian --verbose to work need to downgrade git below 2.14)