### PR TITLE
Fix puppet librarian dependency errors by pinning more versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},
     {"name":"herculesteam-augeasproviders_sysctl","version_requirement":">= 2.0.2 < 2.2.0"},
-    {"name":"threatstack-threatstack","version_requirement":">= 1.5.4"},
+    {"name":"threatstack-threatstack","version_requirement":">= 1.5.4 < 2.0.0"},
     {"name":"KyleAnderson-consul","version_requirement":"3.2.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/FitnessKeeper/puppet-rk_tomcat",
   "issues_url": "https://github.com/FitnessKeeper/puppet-rk_tomcat/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.2 < 1.5.0"},
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},


### PR DESCRIPTION
This fixes an error with puppet librarian dependency resolution.

Note, to view puppet librarian --verbose, need to downgrade git via:

```
yum downgrade git-2.13.6-2.56.amzn1 perl-Git-2.13.6-2.56.amzn1.noarch
```