### PR TITLE
Fix GM build issues from puppet librarian deps and goss tests version pinning SREB-4260

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},
     {"name":"herculesteam-augeasproviders_sysctl","version_requirement":">= 2.0.2 < 2.2.0"},
-    {"name":"threatstack-threatstack","version_requirement":">= 1.5.4"},
+    {"name":"threatstack-threatstack","version_requirement":">= 1.5.4 < 2.0.0"},
     {"name":"KyleAnderson-consul","version_requirement":"3.2.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/FitnessKeeper/puppet-rk_tomcat",
   "issues_url": "https://github.com/FitnessKeeper/puppet-rk_tomcat/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
     {"name":"puppetlabs-tomcat","version_requirement":">= 1.3.2 < 1.5.0"},
     {"name":"puppetlabs-limits","version_requirement":">= 0.1.0"},
     {"name":"maestrodev-wget","version_requirement":">= 1.7.1"},

--- a/templates/goss_provision.json.erb
+++ b/templates/goss_provision.json.erb
@@ -101,13 +101,13 @@
        "<%= @tomcat_native_pkg %>": {
             "installed": true,
             "versions": [
-                "1.2.16"
+                "1.2.21"
             ]
         },
         "<%= @tomcat_pkg %>": {
             "installed": true,
             "versions": [
-                "7.0.90"
+                "7.0.94"
             ]
         },
         <%- @font_pkgs.each do |font_pkg| -%>


### PR DESCRIPTION
This fixes Gold Master build errors by:
- adding version constraints on puppet librarian modules to prevent incompatible requirements
- and updating the versions of packages expected in goss tests