### PR TITLE
[Tomcat] Increase the max wait to 20s and decrease the validation interval to 10s

### DIFF
--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -61,11 +61,11 @@
        type="javax.sql.DataSource"
        maxActive="<%= resource.fetch('maxactive') -%>"
        maxIdle="<%= resource.fetch('maxidle') -%>"
-       maxWait="10000"
+       maxWait="20000"
        removeAbandoned="true"
        validationQuery="select 1"
        testOnBorrow="true"
-       validationInterval="30000" 
+       validationInterval="10000"
        logAbandoned="true" />
 
     <%- end -%>


### PR DESCRIPTION
This PR alters the JDBC Connection pool defaults. This is an attempt to fix the autoshare errors that are coming up when the connection pool becomes exhausted. 